### PR TITLE
Reset base font size, style nav.

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -40,16 +40,16 @@ kbd {
 // Blocks of code
 pre {
   display: block;
-  padding: ((@line-height-computed - 1) / 2);
-  margin: 0 0 (@line-height-computed / 2);
-  font-size: (@font-size-base - 1); // 14px to 13px
+  padding: (@line-height-computed / 2) @line-height-computed;
+  margin: 0 0 @line-height-computed;
+  font-size: (@font-size-base - 0.0625rem); // 16px to 15px
   line-height: @line-height-base;
   word-break: break-all;
   word-wrap: break-word;
   color: @pre-color;
   background-color: @pre-bg;
-  border: 1px solid @pre-border-color;
-  border-radius: @border-radius-base;
+  border-left: 5px solid @pre-border-color;
+
 
   // Account for some code outputs that place code tags in pre tags
   code {

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -193,11 +193,10 @@
 .navbar-toggle {
   position: relative;
   float: right;
-  .navbar-vertical-align(5.245rem);
   background-color: transparent;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
-  border: 1px solid transparent;
-  border-radius: @border-radius-base;
+  border: 0;
+  top: 1.75rem;
 
   // We remove the `outline` here, but later compensate by attaching `:hover`
   // styles to `:focus`.
@@ -208,12 +207,12 @@
   // Bars
   .icon-bar {
     display: block;
-    width: 22px;
-    height: 2px;
-    border-radius: 1px;
+    width: 2.5rem;
+    height: 0.375rem;
+    border-radius: 0;
   }
   .icon-bar + .icon-bar {
-    margin-top: 4px;
+    margin-top: 0.375rem;
   }
 
   @media (min-width: @grid-float-breakpoint) {

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -193,9 +193,7 @@
 .navbar-toggle {
   position: relative;
   float: right;
-  margin-right: @navbar-padding-horizontal;
-  padding: 9px 10px;
-  .navbar-vertical-align(34px);
+  .navbar-vertical-align(5.245rem);
   background-color: transparent;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid transparent;

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -176,7 +176,7 @@
     display: block;
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media (max-width: @grid-float-breakpoint) {
     .navbar > .container &,
     .navbar > .container-fluid & {
       margin-left: -@navbar-padding-horizontal;
@@ -267,8 +267,8 @@
     > li {
       float: left;
       > a {
-        padding-top:    @navbar-padding-vertical;
-        padding-bottom: @navbar-padding-vertical;
+        padding-top:    (@navbar-padding-vertical / 2);
+        padding-bottom: (@navbar-padding-vertical / 2);
         font-size:      @font-size-small;
       }
     }
@@ -555,7 +555,7 @@
       &,
       &:hover,
       &:focus {
-        color: @navbar-inverse-link-active-color;
+        color: @brand-amber;
         background-color: @navbar-inverse-link-active-bg;
       }
     }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -269,6 +269,7 @@
       > a {
         padding-top:    @navbar-padding-vertical;
         padding-bottom: @navbar-padding-vertical;
+        font-size:      @font-size-small;
       }
     }
   }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -315,6 +315,7 @@
     padding-top: 0;
     padding-bottom: 0;
     .box-shadow(none);
+    margin-top: 2rem;
   }
 }
 

--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -23,6 +23,7 @@ input#search-container.form-control {
   border-radius: 0;
   background: #222;
   border: 1px solid #555;
+  color: #fff;
 }
 
 // Skip that table.table thing, man

--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -157,7 +157,7 @@ div#version-note > .noisy {
 /* Blockquote notes */
 blockquote {
   margin-top: 1rem;
-  border-left: 5px solid #ffae1a;
+  border-left: 5px solid @brand-amber;
   border-bottom: 1px solid #ccc;
   background-color: #fafafa;
 }

--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -18,6 +18,13 @@ b, strong {
   font-weight: @font-weight-bold;
 }
 
+// Style navbar search box
+input#search-container.form-control {
+  border-radius: 0;
+  background: #222;
+  border: 1px solid #555;
+}
+
 // Skip that table.table thing, man
 // --------------------------------
 

--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -1,3 +1,9 @@
+// Set the base font-size to match *.puppet.com, so we can also reuse its rem sizes.
+
+html {
+  font-size: 16px;
+}
+
 // Set body text font-weight (Bootstrap has no preference, so the browser defaults it to 400.)
 
 @font-weight-base: 300; /* Calibre Web Light */

--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -154,3 +154,10 @@ div#version-note > .noisy {
   padding: 0.5em;
 }
 
+/* Blockquote notes */
+blockquote {
+  margin-top: 1rem;
+  border-left: 5px solid #ffae1a;
+  border-bottom: 1px solid #ccc;
+  background-color: #fafafa;
+}

--- a/less/variables.less
+++ b/less/variables.less
@@ -49,20 +49,20 @@
 @font-family-base:        @font-family-sans-serif;
 
 @font-size-base:          1.1rem; // 17.6px
-@font-size-large:         ceil((@font-size-base * 1.25));  // ~22px
-@font-size-small:         ceil((@font-size-base * 0.85));  // ~15px
+@font-size-large:         (@font-size-base * 1.25);  // ~22px
+@font-size-small:         (@font-size-base * 0.85);  // ~15px
 
-@font-size-h1:            floor((@font-size-base * 2.6));  // ~46px
-@font-size-h2:            floor((@font-size-base * 2.15)); // ~38px
-@font-size-h3:            ceil((@font-size-base * 1.7));   // ~30px
-@font-size-h4:            ceil((@font-size-base * 1.25));  // ~22px
+@font-size-h1:            (@font-size-base * 2.6);  // ~46px
+@font-size-h2:            (@font-size-base * 2.15); // ~38px
+@font-size-h3:            (@font-size-base * 1.7);   // ~30px
+@font-size-h4:            (@font-size-base * 1.25);  // ~22px
 @font-size-h5:            @font-size-base;
-@font-size-h6:            ceil((@font-size-base * 0.85));  // ~15px
+@font-size-h6:            (@font-size-base * 0.85);  // ~15px
 
 //** Unit-less `line-height` for use in components like buttons.
 @line-height-base:        1.375; // 22/16
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-@line-height-computed:    floor((@font-size-base * @line-height-base)); // ~22px
+@line-height-computed:    (@font-size-base * @line-height-base); // ~22px
 
 //** By default, this inherits from the `<body>`.
 @headings-font-family:    inherit;

--- a/less/variables.less
+++ b/less/variables.less
@@ -48,16 +48,16 @@
 @font-family-monospace:   Inconsolata, Menlo, Monaco, Consolas, Courier, "Courier New", monospace;
 @font-family-base:        @font-family-sans-serif;
 
-@font-size-base:          17px;
-@font-size-large:         ceil((@font-size-base * 1.25)); // ~18px, if base was 14
-@font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
+@font-size-base:          1.1rem; // 17.6px
+@font-size-large:         ceil((@font-size-base * 1.25));  // ~22px
+@font-size-small:         ceil((@font-size-base * 0.85));  // ~15px
 
-@font-size-h1:            floor((@font-size-base * 2.6)); // ~36px, if base was 14
-@font-size-h2:            floor((@font-size-base * 2.15)); // ~30px, if base was 14
-@font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px, if base was 14
-@font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px, if base was 14
+@font-size-h1:            floor((@font-size-base * 2.6));  // ~46px
+@font-size-h2:            floor((@font-size-base * 2.15)); // ~38px
+@font-size-h3:            ceil((@font-size-base * 1.7));   // ~30px
+@font-size-h4:            ceil((@font-size-base * 1.25));  // ~22px
 @font-size-h5:            @font-size-base;
-@font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px, if base was 14
+@font-size-h6:            ceil((@font-size-base * 0.85));  // ~15px
 
 //** Unit-less `line-height` for use in components like buttons.
 @line-height-base:        1.428571429; // 20/14
@@ -361,7 +361,7 @@
 @navbar-margin-bottom:             @line-height-computed;
 @navbar-border-radius:             @border-radius-base;
 @navbar-padding-horizontal:        floor((@grid-gutter-width / 2));
-@navbar-padding-vertical:          ((@navbar-height - @line-height-computed) / 2);
+@navbar-padding-vertical:          1.275rem;
 @navbar-collapse-max-height:       340px;
 
 @navbar-default-color:             #777;

--- a/less/variables.less
+++ b/less/variables.less
@@ -361,7 +361,7 @@
 @navbar-margin-bottom:             @line-height-computed;
 @navbar-border-radius:             @border-radius-base;
 @navbar-padding-horizontal:        0.75rem; // to match other sites
-@navbar-padding-vertical:          1.275rem;  // to match other sites
+@navbar-padding-vertical:          1.32rem;  // to match other sites
 @navbar-collapse-max-height:       340px;
 
 @navbar-default-color:             #777;

--- a/less/variables.less
+++ b/less/variables.less
@@ -60,9 +60,9 @@
 @font-size-h6:            ceil((@font-size-base * 0.85));  // ~15px
 
 //** Unit-less `line-height` for use in components like buttons.
-@line-height-base:        1.428571429; // 20/14
+@line-height-base:        1.375; // 22/16
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-@line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
+@line-height-computed:    floor((@font-size-base * @line-height-base)); // ~22px
 
 //** By default, this inherits from the `<body>`.
 @headings-font-family:    inherit;
@@ -206,7 +206,7 @@
 @input-color-placeholder:        #999;
 
 //** Default `.form-control` height
-@input-height-base:              (@line-height-computed + (@padding-base-vertical * 2) + 2);
+@input-height-base:              2rem; // Match main site.
 //** Large `.form-control` height
 @input-height-large:             (ceil(@font-size-large * @line-height-large) + (@padding-large-vertical * 2) + 2);
 //** Small `.form-control` height

--- a/less/variables.less
+++ b/less/variables.less
@@ -835,7 +835,7 @@
 @kbd-color:                   #fff;
 @kbd-bg:                      #333;
 
-@pre-bg:                      #f5f5f5;
+@pre-bg:                      #fafafa;
 @pre-color:                   @gray-dark;
 @pre-border-color:            #ccc;
 @pre-scrollable-max-height:   340px;

--- a/less/variables.less
+++ b/less/variables.less
@@ -19,7 +19,7 @@
 @brand-info:            #5bc0de;
 @brand-warning:         #f0ad4e;
 @brand-danger:          #d9534f;
-
+@brand-amber:           #ffae1a;
 
 //== Scaffolding
 //
@@ -50,10 +50,10 @@
 
 @font-size-base:          1.1rem; // 17.6px
 @font-size-large:         (@font-size-base * 1.25);  // ~22px
-@font-size-small:         (@font-size-base * 0.85);  // ~15px
+@font-size-small:         (@font-size-base * 0.836364);  // ~14.72px
 
-@font-size-h1:            (@font-size-base * 2.6);  // ~46px
-@font-size-h2:            (@font-size-base * 2.15); // ~38px
+@font-size-h1:            (@font-size-base * 2.6);   // ~46px
+@font-size-h2:            (@font-size-base * 2.15);  // ~38px
 @font-size-h3:            (@font-size-base * 1.7);   // ~30px
 @font-size-h4:            (@font-size-base * 1.25);  // ~22px
 @font-size-h5:            @font-size-base;
@@ -360,8 +360,8 @@
 @navbar-height:                    50px;
 @navbar-margin-bottom:             @line-height-computed;
 @navbar-border-radius:             @border-radius-base;
-@navbar-padding-horizontal:        floor((@grid-gutter-width / 2));
-@navbar-padding-vertical:          1.275rem;
+@navbar-padding-horizontal:        0.75rem; // to match other sites
+@navbar-padding-vertical:          1.275rem;  // to match other sites
 @navbar-collapse-max-height:       340px;
 
 @navbar-default-color:             #777;
@@ -399,7 +399,7 @@
 @navbar-inverse-link-hover-color:           #fff;
 @navbar-inverse-link-hover-bg:              transparent;
 @navbar-inverse-link-active-color:          @navbar-inverse-link-hover-color;
-@navbar-inverse-link-active-bg:             darken(@navbar-inverse-bg, 10%);
+@navbar-inverse-link-active-bg:             @navbar-inverse-bg; // darken(@navbar-inverse-bg, 10%);
 @navbar-inverse-link-disabled-color:        #444;
 @navbar-inverse-link-disabled-bg:           transparent;
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -829,8 +829,8 @@
 //
 //##
 
-@code-color:                  #c7254e;
-@code-bg:                     #f9f2f4;
+@code-color:                  @gray-darker;
+@code-bg:                     @gray-lighter;
 
 @kbd-color:                   #fff;
 @kbd-bg:                      #333;


### PR DESCRIPTION
Changes the base font size assigned to the html tag to 16px and body font size to 1.1rem (17.6px) to match the other Puppet sites.

Since other Less styles are calculated off the base and body font sizes, this also recalculates or modifies those styles. There might be a math-ier way to do this.

Since the form input Less styles are calculated from the body size instead of the base size, adjust the form input styles to prevent the search box from growing too large as a result.
